### PR TITLE
feat(scope): patch store to avoid patching hooks

### DIFF
--- a/examples/02_scope/src/App.tsx
+++ b/examples/02_scope/src/App.tsx
@@ -1,5 +1,5 @@
-import { atom } from 'jotai';
-import { ScopeProvider, useAtom } from 'jotai-scope';
+import { atom, useAtom } from 'jotai';
+import { ScopeProvider } from 'jotai-scope';
 
 const countAtom = atom(0);
 const anotherCountAtom = atom(0);

--- a/src/createScope.tsx
+++ b/src/createScope.tsx
@@ -7,7 +7,9 @@ type AnyAtom = Atom<unknown>;
 type AnyWritableAtom = WritableAtom<unknown, unknown[], unknown>;
 type GetScopedAtom = <T extends AnyAtom>(anAtom: T) => T;
 
-const ScopeContext = createContext<GetScopedAtom>((a) => a);
+export const ScopeContext = createContext<
+  readonly [GetScopedAtom, Set<AnyAtom>]
+>([(a) => a, new Set()]);
 
 export const ScopeProvider = ({
   atoms,
@@ -16,7 +18,7 @@ export const ScopeProvider = ({
   atoms: Iterable<AnyAtom>;
   children: ReactNode;
 }) => {
-  const getParentScopedAtom = useContext(ScopeContext);
+  const [getParentScopedAtom] = useContext(ScopeContext);
   const mapping = new WeakMap<AnyAtom, AnyAtom>();
   const atomSet = new Set(atoms);
 
@@ -79,13 +81,8 @@ export const ScopeProvider = ({
   };
 
   return (
-    <ScopeContext.Provider value={getScopedAtom}>
+    <ScopeContext.Provider value={[getScopedAtom, atomSet]}>
       <Provider store={patchedStore}>{children}</Provider>
     </ScopeContext.Provider>
   );
-};
-
-export const useScopedAtom = <T extends Atom<any>>(anAtom: T): T => {
-  const getScopedAtom = useContext(ScopeContext);
-  return getScopedAtom(anAtom);
 };

--- a/src/createScope.tsx
+++ b/src/createScope.tsx
@@ -1,11 +1,6 @@
 import { createContext, useContext } from 'react';
 import type { ReactNode } from 'react';
-import {
-  useAtom as useAtomOrig,
-  useAtomValue as useAtomValueOrig,
-  useSetAtom as useSetAtomOrig,
-} from 'jotai/react';
-import { useHydrateAtoms as useHydrateAtomsOrig } from 'jotai/react/utils';
+import { Provider, useStore } from 'jotai/react';
 import type { Atom, WritableAtom } from 'jotai/vanilla';
 
 type AnyAtom = Atom<unknown>;
@@ -75,9 +70,17 @@ export const ScopeProvider = ({
     return scopedAtom as typeof anAtom;
   };
 
+  const store = useStore();
+  const patchedStore: typeof store = {
+    ...store,
+    get: (anAtom, ...args) => store.get(getScopedAtom(anAtom), ...args),
+    set: (anAtom, ...args) => store.set(getScopedAtom(anAtom), ...args),
+    sub: (anAtom, ...args) => store.sub(getScopedAtom(anAtom), ...args),
+  };
+
   return (
     <ScopeContext.Provider value={getScopedAtom}>
-      {children}
+      <Provider store={patchedStore}>{children}</Provider>
     </ScopeContext.Provider>
   );
 };
@@ -86,24 +89,3 @@ export const useScopedAtom = <T extends Atom<any>>(anAtom: T): T => {
   const getScopedAtom = useContext(ScopeContext);
   return getScopedAtom(anAtom);
 };
-
-export const useAtom = ((anAtom: AnyAtom, ...args: any[]) =>
-  useAtomOrig(useScopedAtom(anAtom), ...args)) as typeof useAtomOrig;
-
-export const useAtomValue = ((anAtom: AnyAtom, ...args: any[]) =>
-  useAtomValueOrig(useScopedAtom(anAtom), ...args)) as typeof useAtomValueOrig;
-
-export const useSetAtom = ((anAtom: AnyWritableAtom, ...args: any[]) =>
-  useSetAtomOrig(useScopedAtom(anAtom), ...args)) as typeof useSetAtomOrig;
-
-export const useHydrateAtoms = ((
-  values: Iterable<readonly [AnyAtom, unknown]>,
-  ...args: any[]
-) => {
-  const getScopedAtom = useContext(ScopeContext);
-  const scopedValues = new Map();
-  for (const [atom, value] of values) {
-    scopedValues.set(getScopedAtom(atom), value);
-  }
-  return useHydrateAtomsOrig(scopedValues, ...args);
-}) as typeof useHydrateAtomsOrig;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,5 @@
 export { createIsolation } from './createIsolation';
-export { ScopeProvider, useScopedAtom } from './createScope';
+export {
+  ScopeContext as INTERNAL_ScopeContext,
+  ScopeProvider,
+} from './createScope';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,2 @@
 export { createIsolation } from './createIsolation';
-export {
-  ScopeProvider,
-  useScopedAtom,
-  useAtom,
-  useAtomValue,
-  useSetAtom,
-  useHydrateAtoms,
-} from './createScope';
+export { ScopeProvider, useScopedAtom } from './createScope';


### PR DESCRIPTION
@yf-yang gave a nice insight. Patching is hard. This patches store instead of hooks.
This is like the combination of the first impl #2 and the second impl #5.
Having Provider in the ScopeProvider tree may result in a weird behavior, but it's probably rare, or it's not recommended.

close #8 