### PR TITLE
feat(scope): A complete rewrite of ScopeProvider (#16, #17)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,9 +17,7 @@
       "node": {
         "extensions": [".js", ".ts", ".tsx"]
       },
-      "typescript": {
-        "project": ["./tsconfig.json"]
-      }
+      "typescript": true
     }
   },
   "rules": {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,6 +16,9 @@
     "import/resolver": {
       "node": {
         "extensions": [".js", ".ts", ".tsx"]
+      },
+      "typescript": {
+        "project": ["./tsconfig.json"]
       }
     }
   },

--- a/examples/03_hybrid/src/App.tsx
+++ b/examples/03_hybrid/src/App.tsx
@@ -1,6 +1,7 @@
 import { WritableAtom, atom, useAtom } from 'jotai';
 import { ScopeProvider } from 'jotai-scope';
 import { useHydrateAtoms } from 'jotai/react/utils';
+import { INTERNAL_InferAtomTuples } from 'jotai/react/utils/useHydrateAtoms';
 import { PropsWithChildren } from 'react';
 
 const primitiveAtom = atom(0);
@@ -81,22 +82,15 @@ const Counter2 = () => {
   );
 };
 
-// Copied from useHydrateAtoms type signature
 type AnyWritableAtom = WritableAtom<unknown, any[], any>;
-type AtomTuple<A = AnyWritableAtom, V = unknown> = readonly [A, V];
-type InferAtoms<T extends Iterable<AtomTuple>> = {
-  [K in keyof T]: T[K] extends AtomTuple<infer A>
-    ? A extends AnyWritableAtom
-      ? AtomTuple<A, ReturnType<A['read']>>
-      : T[K]
-    : never;
-};
 
-const ScopeProviderWithInitializer = <T extends Iterable<AtomTuple>>({
+const ScopeProviderWithInitializer = <
+  T extends Iterable<readonly [AnyWritableAtom, unknown]>,
+>({
   atomValues,
   children,
 }: PropsWithChildren<{
-  atomValues: InferAtoms<T>;
+  atomValues: INTERNAL_InferAtomTuples<T>;
 }>) => {
   const atoms = Array.from(atomValues, ([anAtom]) => anAtom);
   return (
@@ -106,11 +100,13 @@ const ScopeProviderWithInitializer = <T extends Iterable<AtomTuple>>({
   );
 };
 
-const AtomsHydrator = <T extends Iterable<AtomTuple>>({
+const AtomsHydrator = <
+  T extends Iterable<readonly [AnyWritableAtom, unknown]>,
+>({
   atomValues,
   children,
 }: PropsWithChildren<{
-  atomValues: InferAtoms<T>;
+  atomValues: INTERNAL_InferAtomTuples<T>;
 }>) => {
   useHydrateAtoms(atomValues);
   return children;

--- a/examples/04_reducer/package.json
+++ b/examples/04_reducer/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "jotai-scope-example",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "@types/react": "latest",
+    "@types/react-dom": "latest",
+    "jotai": "latest",
+    "jotai-scope": "latest",
+    "react": "latest",
+    "react-dom": "latest",
+    "react-scripts": "latest",
+    "typescript": "latest"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test",
+    "eject": "react-scripts eject"
+  },
+  "browserslist": [
+    ">0.2%",
+    "not dead",
+    "not ie <= 11",
+    "not op_mini all"
+  ]
+}

--- a/examples/04_reducer/public/index.html
+++ b/examples/04_reducer/public/index.html
@@ -1,0 +1,8 @@
+<html>
+  <head>
+    <title>jotai-scope example</title>
+  </head>
+  <body>
+    <div id="app"></div>
+  </body>
+</html>

--- a/examples/04_reducer/src/App.tsx
+++ b/examples/04_reducer/src/App.tsx
@@ -53,7 +53,7 @@ const App = () => {
       <ScopeProvider atoms={[anotherCountAtom]}>
         <Counter />
 
-        <h1>Thrid Provider</h1>
+        <h1>Third Provider</h1>
         <ScopeProvider atoms={[anotherCountAtom]}>
           <Counter />
         </ScopeProvider>

--- a/examples/04_reducer/src/App.tsx
+++ b/examples/04_reducer/src/App.tsx
@@ -1,0 +1,65 @@
+import { useAtom } from 'jotai';
+import { ScopeProvider } from 'jotai-scope';
+import { atomWithReducer } from 'jotai/vanilla/utils';
+
+function createCountAtom() {
+  type State = number;
+  type Action = '+1' | '-1';
+
+  const reducer = (prev: State, action: Action) => {
+    switch (action) {
+      case '+1':
+        return prev + 1;
+      case '-1':
+        return prev - 1;
+      default:
+        throw new Error();
+    }
+  };
+
+  return atomWithReducer(0, reducer);
+}
+
+const countAtom = createCountAtom();
+const anotherCountAtom = createCountAtom();
+
+const Counter = () => {
+  const [count, dispatch] = useAtom(countAtom);
+  const [anotherCount, dispatchAnother] = useAtom(anotherCountAtom);
+  return (
+    <>
+      <div>
+        <span>count: {count}</span>
+        <button type="button" onClick={() => dispatch('+1')}>
+          increment
+        </button>
+      </div>
+      <div>
+        <span>another count: {anotherCount}</span>
+        <button type="button" onClick={() => dispatchAnother('+1')}>
+          increment
+        </button>
+      </div>
+    </>
+  );
+};
+
+const App = () => {
+  return (
+    <div>
+      <h1>First Provider</h1>
+      <Counter />
+      <h1>Second Provider</h1>
+      <ScopeProvider atoms={[anotherCountAtom]}>
+        <Counter />
+
+        <h1>Thrid Provider</h1>
+        <ScopeProvider atoms={[anotherCountAtom]}>
+          <Counter />
+        </ScopeProvider>
+      </ScopeProvider>
+    </div>
+  );
+};
+
+export default App;

--- a/examples/04_reducer/src/App.tsx
+++ b/examples/04_reducer/src/App.tsx
@@ -50,11 +50,11 @@ const App = () => {
       <h1>First Provider</h1>
       <Counter />
       <h1>Second Provider</h1>
-      <ScopeProvider atoms={[anotherCountAtom]}>
+      <ScopeProvider atoms={[anotherCountAtom]} tag="abc">
         <Counter />
 
         <h1>Third Provider</h1>
-        <ScopeProvider atoms={[anotherCountAtom]}>
+        <ScopeProvider atoms={[anotherCountAtom]} tag="def">
           <Counter />
         </ScopeProvider>
       </ScopeProvider>

--- a/examples/04_reducer/src/App.tsx
+++ b/examples/04_reducer/src/App.tsx
@@ -50,11 +50,11 @@ const App = () => {
       <h1>First Provider</h1>
       <Counter />
       <h1>Second Provider</h1>
-      <ScopeProvider atoms={[anotherCountAtom]} tag="abc">
+      <ScopeProvider atoms={[anotherCountAtom]}>
         <Counter />
 
         <h1>Third Provider</h1>
-        <ScopeProvider atoms={[anotherCountAtom]} tag="def">
+        <ScopeProvider atoms={[anotherCountAtom]}>
           <Counter />
         </ScopeProvider>
       </ScopeProvider>

--- a/examples/04_reducer/src/index.tsx
+++ b/examples/04_reducer/src/index.tsx
@@ -1,0 +1,8 @@
+import { createRoot } from 'react-dom/client';
+
+import App from './App';
+
+const ele = document.getElementById('app');
+if (ele) {
+  createRoot(ele).render(<App />);
+}

--- a/examples/05_removeScope/package.json
+++ b/examples/05_removeScope/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "jotai-scope-example",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "@types/react": "latest",
+    "@types/react-dom": "latest",
+    "jotai": "latest",
+    "jotai-scope": "latest",
+    "react": "latest",
+    "react-dom": "latest",
+    "react-scripts": "latest",
+    "typescript": "latest"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test",
+    "eject": "react-scripts eject"
+  },
+  "browserslist": [
+    ">0.2%",
+    "not dead",
+    "not ie <= 11",
+    "not op_mini all"
+  ]
+}

--- a/examples/05_removeScope/public/index.html
+++ b/examples/05_removeScope/public/index.html
@@ -1,0 +1,8 @@
+<html>
+  <head>
+    <title>jotai-scope example</title>
+  </head>
+  <body>
+    <div id="app"></div>
+  </body>
+</html>

--- a/examples/05_removeScope/src/App.tsx
+++ b/examples/05_removeScope/src/App.tsx
@@ -44,11 +44,9 @@ const Wrapper = ({ children }: PropsWithChildren) => {
 const ScopeButton = () => {
   const [shouldHaveScope, setShouldHaveScope] = useAtom(shouldHaveScopeAtom);
   return (
-    shouldHaveScope && (
-      <button type="button" onClick={() => setShouldHaveScope(false)}>
-        Disable Scope
-      </button>
-    )
+    <button type="button" onClick={() => setShouldHaveScope((prev) => !prev)}>
+      {shouldHaveScope ? 'Disable' : 'Enable'} Scope
+    </button>
   );
 };
 

--- a/examples/05_removeScope/src/App.tsx
+++ b/examples/05_removeScope/src/App.tsx
@@ -1,0 +1,73 @@
+import { atom, useAtom, useAtomValue } from 'jotai';
+import { ScopeProvider } from 'jotai-scope';
+import { atomWithReducer } from 'jotai/vanilla/utils';
+import { PropsWithChildren } from 'react';
+
+const countAtom = atomWithReducer(0, (v) => v + 1);
+const anotherCountAtom = atomWithReducer(0, (v) => v + 1);
+const doubledAnotherCountAtom = atom((get) => get(anotherCountAtom) * 2);
+const shouldHaveScopeAtom = atom(true);
+
+const Counter = () => {
+  const [count, setCount] = useAtom(countAtom);
+  const [anotherCount, setAnotherCount] = useAtom(anotherCountAtom);
+  const [doubledAnotherCount] = useAtom(doubledAnotherCountAtom);
+  return (
+    <>
+      <div>
+        <span>count: {count}</span>
+        <button type="button" onClick={() => setCount()}>
+          increment
+        </button>
+      </div>
+      <div>
+        <span>
+          another count: {anotherCount} (doubled: {doubledAnotherCount})
+        </span>
+        <button type="button" onClick={() => setAnotherCount()}>
+          increment
+        </button>
+      </div>
+    </>
+  );
+};
+
+const Wrapper = ({ children }: PropsWithChildren) => {
+  const shouldHaveScope = useAtomValue(shouldHaveScopeAtom);
+  return shouldHaveScope ? (
+    <ScopeProvider atoms={[anotherCountAtom]}>{children}</ScopeProvider>
+  ) : (
+    children
+  );
+};
+
+const ScopeButton = () => {
+  const [shouldHaveScope, setShouldHaveScope] = useAtom(shouldHaveScopeAtom);
+  return (
+    shouldHaveScope && (
+      <button type="button" onClick={() => setShouldHaveScope(false)}>
+        Disable Scope
+      </button>
+    )
+  );
+};
+
+const App = () => {
+  return (
+    <div>
+      <h1>Unscoped</h1>
+      <Counter />
+      <h1>First Provider</h1>
+      <Wrapper>
+        <Counter />
+      </Wrapper>
+      <h1>Second Provider</h1>
+      <Wrapper>
+        <Counter />
+      </Wrapper>
+      <ScopeButton />
+    </div>
+  );
+};
+
+export default App;

--- a/examples/05_removeScope/src/index.tsx
+++ b/examples/05_removeScope/src/index.tsx
@@ -1,0 +1,8 @@
+import { createRoot } from 'react-dom/client';
+
+import App from './App';
+
+const ele = document.getElementById('app');
+if (ele) {
+  createRoot(ele).render(<App />);
+}

--- a/examples/06_nested/package.json
+++ b/examples/06_nested/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "jotai-scope-example",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "@types/react": "latest",
+    "@types/react-dom": "latest",
+    "jotai": "latest",
+    "jotai-scope": "latest",
+    "react": "latest",
+    "react-dom": "latest",
+    "react-scripts": "latest",
+    "typescript": "latest"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test",
+    "eject": "react-scripts eject"
+  },
+  "browserslist": [
+    ">0.2%",
+    "not dead",
+    "not ie <= 11",
+    "not op_mini all"
+  ]
+}

--- a/examples/06_nested/public/index.html
+++ b/examples/06_nested/public/index.html
@@ -1,0 +1,8 @@
+<html>
+  <head>
+    <title>jotai-scope example</title>
+  </head>
+  <body>
+    <div id="app"></div>
+  </body>
+</html>

--- a/examples/06_nested/src/App.tsx
+++ b/examples/06_nested/src/App.tsx
@@ -1,0 +1,60 @@
+import { atom, useAtom, useSetAtom } from 'jotai';
+import { ScopeProvider } from 'jotai-scope';
+import { atomWithReducer } from 'jotai/vanilla/utils';
+
+const countAtom = atomWithReducer(0, (v) => v + 1);
+const anotherCountAtom = atomWithReducer(0, (v) => v + 1);
+const doubledAnotherCountAtom = atom((get) => get(anotherCountAtom) * 2);
+const proxyAtom = atom(undefined, (_get, set) => {
+  set(countAtom);
+  set(anotherCountAtom);
+});
+
+const Counter = () => {
+  const [count, setCount] = useAtom(countAtom);
+  const [anotherCount, setAnotherCount] = useAtom(anotherCountAtom);
+  const [doubledAnotherCount] = useAtom(doubledAnotherCountAtom);
+  const setViaProxy = useSetAtom(proxyAtom);
+  return (
+    <>
+      <div>
+        <span>count: {count}</span>
+        <button type="button" onClick={() => setCount()}>
+          increment
+        </button>
+      </div>
+      <div>
+        <span>
+          another count: {anotherCount} (doubled: {doubledAnotherCount})
+        </span>
+        <button type="button" onClick={() => setAnotherCount()}>
+          increment
+        </button>
+      </div>
+      <div>
+        <button type="button" onClick={() => setViaProxy()}>
+          increment both via proxy
+        </button>
+      </div>
+    </>
+  );
+};
+
+const App = () => {
+  return (
+    <div>
+      <h1>Unscoped</h1>
+      <Counter />
+      <h1>Scope count</h1>
+      <ScopeProvider atoms={[countAtom]}>
+        <Counter />
+        <h1>Nested scope another count</h1>
+        <ScopeProvider atoms={[anotherCountAtom]}>
+          <Counter />
+        </ScopeProvider>
+      </ScopeProvider>
+    </div>
+  );
+};
+
+export default App;

--- a/examples/06_nested/src/App.tsx
+++ b/examples/06_nested/src/App.tsx
@@ -1,11 +1,12 @@
-import { atom, useAtom, useSetAtom } from 'jotai';
+import { atom, useAtom } from 'jotai';
 import { ScopeProvider } from 'jotai-scope';
 import { atomWithReducer } from 'jotai/vanilla/utils';
 
 const countAtom = atomWithReducer(0, (v) => v + 1);
 const anotherCountAtom = atomWithReducer(0, (v) => v + 1);
 const doubledAnotherCountAtom = atom((get) => get(anotherCountAtom) * 2);
-const proxyAtom = atom(undefined, (_get, set) => {
+const proxyAtom = atom(0, (_get, set, v: number) => {
+  set(proxyAtom, v);
   set(countAtom);
   set(anotherCountAtom);
 });
@@ -14,7 +15,7 @@ const Counter = () => {
   const [count, setCount] = useAtom(countAtom);
   const [anotherCount, setAnotherCount] = useAtom(anotherCountAtom);
   const [doubledAnotherCount] = useAtom(doubledAnotherCountAtom);
-  const setViaProxy = useSetAtom(proxyAtom);
+  const [proxy, setProxy] = useAtom(proxyAtom);
   return (
     <>
       <div>
@@ -32,7 +33,8 @@ const Counter = () => {
         </button>
       </div>
       <div>
-        <button type="button" onClick={() => setViaProxy()}>
+        <span>proxy: {proxy}</span>
+        <button type="button" onClick={() => setProxy(proxy + 1)}>
           increment both via proxy
         </button>
       </div>

--- a/examples/06_nested/src/index.tsx
+++ b/examples/06_nested/src/index.tsx
@@ -1,0 +1,8 @@
+import { createRoot } from 'react-dom/client';
+
+import App from './App';
+
+const ele = document.getElementById('app');
+if (ele) {
+  createRoot(ele).render(<App />);
+}

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "html-webpack-plugin": "^5.5.3",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
-    "jotai": "^2.5.0",
+    "jotai": "^2.6.3",
     "microbundle": "^0.15.1",
     "npm-run-all": "^4.1.5",
     "prettier": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,9 @@
     "tsc-test": "tsc --project . --noEmit",
     "examples:01_isolation": "DIR=01_isolation EXT=tsx webpack serve",
     "examples:02_scope": "DIR=02_scope EXT=tsx webpack serve",
-    "examples:03_hybrid": "DIR=03_hybrid EXT=tsx webpack serve"
+    "examples:03_hybrid": "DIR=03_hybrid EXT=tsx webpack serve",
+    "examples:04_reducer": "DIR=04_reducer EXT=tsx webpack serve",
+    "examples:05_removeScope": "DIR=05_removeScope EXT=tsx webpack serve"
   },
   "jest": {
     "testEnvironment": "jsdom",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "examples:02_scope": "DIR=02_scope EXT=tsx webpack serve",
     "examples:03_hybrid": "DIR=03_hybrid EXT=tsx webpack serve",
     "examples:04_reducer": "DIR=04_reducer EXT=tsx webpack serve",
-    "examples:05_removeScope": "DIR=05_removeScope EXT=tsx webpack serve"
+    "examples:05_removeScope": "DIR=05_removeScope EXT=tsx webpack serve",
+    "examples:06_nested": "DIR=06_nested EXT=tsx webpack serve"
   },
   "jest": {
     "testEnvironment": "jsdom",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "eslint": "^8.52.0",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-prettier": "^9.0.0",
+    "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-import": "^2.29.0",
     "eslint-plugin-jsx-a11y": "^6.7.1",
     "eslint-plugin-prettier": "^5.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 devDependencies:
   '@testing-library/dom':
     specifier: ^9.3.3
@@ -59,8 +63,8 @@ devDependencies:
     specifier: ^29.7.0
     version: 29.7.0
   jotai:
-    specifier: ^2.5.0
-    version: 2.5.0(@types/react@18.2.31)(react@18.2.0)
+    specifier: ^2.6.3
+    version: 2.6.3(@types/react@18.2.31)(react@18.2.0)
   microbundle:
     specifier: ^0.15.1
     version: 0.15.1
@@ -5901,8 +5905,8 @@ packages:
       - ts-node
     dev: true
 
-  /jotai@2.5.0(@types/react@18.2.31)(react@18.2.0):
-    resolution: {integrity: sha512-iPJDFrhNw3KU4o4SSAESeZoW+nM1L/76VULXZWF23qmivBEcbAQjiF5n1W4Hn5dXAol4tmtEYe4HH7d9emEz0Q==}
+  /jotai@2.6.3(@types/react@18.2.31)(react@18.2.0):
+    resolution: {integrity: sha512-0htSJ2d6426ZdSEYHncJHXY6Lkgde1Hc2HE/ADIRi9d2L3hQL+jLKY1LkWBMeCNyOSlKH8+1u/Gc33Ox0uq21Q==}
     engines: {node: '>=12.20.0'}
     peerDependencies:
       '@types/react': '>=17.0.0'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,9 +41,12 @@ devDependencies:
   eslint-config-prettier:
     specifier: ^9.0.0
     version: 9.0.0(eslint@8.52.0)
+  eslint-import-resolver-typescript:
+    specifier: ^3.6.1
+    version: 3.6.1(@typescript-eslint/parser@6.8.0)(eslint-plugin-import@2.29.0)(eslint@8.52.0)
   eslint-plugin-import:
     specifier: ^2.29.0
-    version: 2.29.0(@typescript-eslint/parser@6.8.0)(eslint@8.52.0)
+    version: 2.29.0(@typescript-eslint/parser@6.8.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.52.0)
   eslint-plugin-jsx-a11y:
     specifier: ^6.7.1
     version: 6.7.1(eslint@8.52.0)
@@ -4009,7 +4012,7 @@ packages:
     dependencies:
       confusing-browser-globals: 1.0.11
       eslint: 8.52.0
-      eslint-plugin-import: 2.29.0(@typescript-eslint/parser@6.8.0)(eslint@8.52.0)
+      eslint-plugin-import: 2.29.0(@typescript-eslint/parser@6.8.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.52.0)
       object.assign: 4.1.4
       object.entries: 1.1.7
       semver: 6.3.1
@@ -4027,7 +4030,7 @@ packages:
     dependencies:
       eslint: 8.52.0
       eslint-config-airbnb-base: 15.0.0(eslint-plugin-import@2.29.0)(eslint@8.52.0)
-      eslint-plugin-import: 2.29.0(@typescript-eslint/parser@6.8.0)(eslint@8.52.0)
+      eslint-plugin-import: 2.29.0(@typescript-eslint/parser@6.8.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.52.0)
       eslint-plugin-jsx-a11y: 6.7.1(eslint@8.52.0)
       eslint-plugin-react: 7.33.2(eslint@8.52.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.52.0)
@@ -4054,7 +4057,30 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-module-utils@2.8.0(@typescript-eslint/parser@6.8.0)(eslint-import-resolver-node@0.3.9)(eslint@8.52.0):
+  /eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.8.0)(eslint-plugin-import@2.29.0)(eslint@8.52.0):
+    resolution: {integrity: sha512-xgdptdoi5W3niYeuQxKmzVDTATvLYqhpwmykwsh7f6HIOStGWEIL9iqZgQDF9u9OEzrRwR8no5q2VT+bjAujTg==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      eslint: '*'
+      eslint-plugin-import: '*'
+    dependencies:
+      debug: 4.3.4
+      enhanced-resolve: 5.15.0
+      eslint: 8.52.0
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.8.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.52.0)
+      eslint-plugin-import: 2.29.0(@typescript-eslint/parser@6.8.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.52.0)
+      fast-glob: 3.3.1
+      get-tsconfig: 4.7.2
+      is-core-module: 2.13.1
+      is-glob: 4.0.3
+    transitivePeerDependencies:
+      - '@typescript-eslint/parser'
+      - eslint-import-resolver-node
+      - eslint-import-resolver-webpack
+      - supports-color
+    dev: true
+
+  /eslint-module-utils@2.8.0(@typescript-eslint/parser@6.8.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.52.0):
     resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -4079,11 +4105,12 @@ packages:
       debug: 3.2.7
       eslint: 8.52.0
       eslint-import-resolver-node: 0.3.9
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.8.0)(eslint-plugin-import@2.29.0)(eslint@8.52.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /eslint-plugin-import@2.29.0(@typescript-eslint/parser@6.8.0)(eslint@8.52.0):
+  /eslint-plugin-import@2.29.0(@typescript-eslint/parser@6.8.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.52.0):
     resolution: {integrity: sha512-QPOO5NO6Odv5lpoTkddtutccQjysJuFxoPS7fAHO+9m9udNHvTCPSAMW9zGAYj8lAIdr40I8yPCdUYrncXtrwg==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -4102,7 +4129,7 @@ packages:
       doctrine: 2.1.0
       eslint: 8.52.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.8.0)(eslint-import-resolver-node@0.3.9)(eslint@8.52.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.8.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.52.0)
       hasown: 2.0.0
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -4686,6 +4713,12 @@ packages:
     dependencies:
       call-bind: 1.0.5
       get-intrinsic: 1.2.2
+    dev: true
+
+  /get-tsconfig@4.7.2:
+    resolution: {integrity: sha512-wuMsz4leaj5hbGgg4IvDU0bqJagpftG5l5cXIAvo8uZrqn0NJqwtfupTN00VnkQJPcIRrxYrm1Ue24btpCha2A==}
+    dependencies:
+      resolve-pkg-maps: 1.0.0
     dev: true
 
   /glob-parent@5.1.2:
@@ -7557,6 +7590,10 @@ packages:
   /resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
+    dev: true
+
+  /resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
     dev: true
 
   /resolve.exports@2.0.2:

--- a/src/ScopeProvider.tsx
+++ b/src/ScopeProvider.tsx
@@ -73,7 +73,7 @@ export const ScopeProvider = ({
        * }
        */
       const getAtom = <A extends AnyAtom>(orig: AnyAtom, target: A): A => {
-        // If a target is got/set by itself, then it is derived.
+        // If a target is got/set by itself, then it is not derived.
         // Target could be an intercepted copy, so target is on the left.
         if (isSelfAtom(target, orig)) {
           // Since it is not derived, we check if it is marked as scoped.

--- a/src/ScopeProvider.tsx
+++ b/src/ScopeProvider.tsx
@@ -1,7 +1,8 @@
 import { createContext, useContext, useState } from 'react';
 import type { ReactNode } from 'react';
 import { Provider, useStore } from 'jotai/react';
-import { Atom, WritableAtom, getDefaultStore } from 'jotai/vanilla';
+import { getDefaultStore } from 'jotai/vanilla';
+import type { Atom, WritableAtom } from 'jotai/vanilla';
 
 type AnyAtom = Atom<unknown>;
 type AnyWritableAtom = WritableAtom<unknown, unknown[], unknown>;


### PR DESCRIPTION
fixes #16, #17
depends on https://github.com/pmndrs/jotai/pull/2356
To give it a try, use [`pnpm add`, `yarn add`, `npm i`] https://pkg.csb.dev/pmndrs/jotai/commit/3b6440d1/jotai

# Root Cause Analysis

Take a look of this atom:
``` javascript
function atomWithReducer(initialValue, reducer) {
  const anAtom = atom(initialValue, (get, set, action) =>
    set(anAtom, reducer(get(anAtom), action)),
  )
  return anAtom
}
const myAtom = atomWithReducer(...);

// somewhere in a React component
const dispatch = useSetAtom(myAtom);
```
Note that the condition `myAtom === anAtom` evals to true, which means they are exactly the same atom. Then, why `dispatch(action)` calls `reducer(action)`, but `set(anAtom, reducedValue)` directly updates the value of `anAtom` instead of calling `reducer(reducedValue)`?

The key is here: https://github.com/pmndrs/jotai/blob/b5c38081e922b56621c6da9b9c32ef3d0f46e4b3/src/vanilla/store.ts#L527, `a === atom` check
``` javascript
const writeAtomState = <Value, Args extends unknown[], Result>(
  atom: WritableAtom<Value, Args, Result>,
  ...args: Args
): Result => {
  let isSync = true
  const getter: Getter = <V>(a: Atom<V>) => returnAtomValue(readAtomState(a))
  const setter: Setter = <V, As extends unknown[], R>(
    a: WritableAtom<V, As, R>,
    ...args: As
  ) => {
    let r: R | undefined
    if ((a as AnyWritableAtom) === atom) {
      if (!hasInitialValue(a)) {
        // NOTE technically possible but restricted as it may cause bugs
        throw new Error('atom not writable')
      }
      const prevAtomState = getAtomState(a)
      const nextAtomState = setAtomValueOrPromise(a, args[0] as V)
      if (!isEqualAtomValue(prevAtomState, nextAtomState)) {
        recomputeDependents(a)
      }
    } else {
      r = writeAtomState(a as AnyWritableAtom, ...args) as R
    }
    if (!isSync) {
      const flushed = flushPending()
      if (import.meta.env?.MODE !== 'production') {
        storeListenersRev2.forEach((l) =>
          l({ type: 'async-write', flushed: flushed as Set<AnyAtom> }),
        )
      }
    }
    return r as R
  }
  const result = atom.write(getter, setter, ...args)
  isSync = false
  return result
}
```
The line (`a === atom` check) checks if an atom is setting itself, so instead of calling the setter again, it directly update the value.


# TODO
- [x] test with examples
- [x] refactor the code structure
- [x] change some obscure parameter names
- [x] add in-code docs 