### PR TITLE
feat: add no-scope api to ScopeProvider

### DIFF
--- a/__tests__/ScopeProvider/08_noscope.tsx
+++ b/__tests__/ScopeProvider/08_noscope.tsx
@@ -1,0 +1,65 @@
+import { render } from '@testing-library/react';
+import { atom, useAtomValue } from 'jotai';
+import { getTextContents } from '../utils';
+import { ScopeProvider } from '../../src/index';
+
+let i = 1;
+const AtomA = atom(() => i++);
+const AtomB = atom((get) => get(AtomA));
+
+const Child = ({ level }: { level?: string }) => {
+  const valueA = useAtomValue(AtomA);
+  const valueB = useAtomValue(AtomB);
+  return (
+    <div className={level}>
+      Atom A is not scoped so its value should always be 1
+      <div className="valueA">{valueA}</div>
+      Atom B is scoped, so its will use the implicitly scoped Atom A
+      <div className="valueB">{valueB}</div>
+    </div>
+  );
+};
+
+/*
+  AtomA
+  S0[]: AtomA0
+  S1[AtomA!]: AtomA!
+  S2[]: AtomA!
+*/
+const App = () => {
+  return (
+    <div className="App">
+      <Child level="level0" />
+      <ScopeProvider atoms={[AtomB]} noScope={[AtomA]} debugName="level1">
+        <Child level="level1" />
+        <ScopeProvider atoms={[]} debugName="level2">
+          <Child level="level2" />
+        </ScopeProvider>
+      </ScopeProvider>
+    </div>
+  );
+};
+
+const { container } = render(<App />);
+
+describe('No Scope', () => {
+  test('AtomA is not scoped so its value should always be 1', () => {
+    const selectors = [
+      '.level0 .valueA',
+      '.level0 .valueB',
+      '.level1 .valueA',
+      '.level1 .valueB',
+      '.level2 .valueA',
+      '.level2 .valueB',
+    ];
+
+    expect(getTextContents(container, selectors)).toEqual([
+      '1', // level0 valueA
+      '1', // level0 valueB
+      '1', // level1 valueA
+      '2', // level1 valueB
+      '1', // level1 valueA
+      '2', // level1 valueB
+    ]);
+  });
+});

--- a/src/ScopeProvider/ScopeProvider.tsx
+++ b/src/ScopeProvider/ScopeProvider.tsx
@@ -12,16 +12,22 @@ import { createPatchedStore, isTopLevelScope } from './patchedStore';
 const ScopeContext = createContext<{
   scope: Scope | undefined;
   baseStore: Store | undefined;
-}>({ scope: undefined, baseStore: undefined });
+  noScopeSet: Set<AnyAtom>;
+}>({ scope: undefined, baseStore: undefined, noScopeSet: new Set() });
 
 export const ScopeProvider = ({
   atoms,
+  noScope = [],
   children,
   debugName,
-}: PropsWithChildren<{ atoms: Iterable<AnyAtom>; debugName?: string }>) => {
+}: PropsWithChildren<{
+  atoms: Iterable<AnyAtom>;
+  noScope?: Iterable<AnyAtom>;
+  debugName?: string;
+}>) => {
   const parentStore: Store = useStore();
-  let { scope: parentScope, baseStore = parentStore } =
-    useContext(ScopeContext);
+  const { noScopeSet: parentNoScopeSet, ...parent } = useContext(ScopeContext);
+  let { scope: parentScope, baseStore = parentStore } = parent;
   // if this ScopeProvider is the first descendant scope under Provider then it is the top level scope
   // https://github.com/jotaijs/jotai-scope/pull/33#discussion_r1604268003
   if (isTopLevelScope(parentStore)) {
@@ -31,21 +37,25 @@ export const ScopeProvider = ({
 
   // atomSet is used to detect if the atoms prop has changed.
   const atomSet = new Set(atoms);
+  // noScopeSet defines atoms that should not be scoped
+  const noScopeSet = new Set([...noScope, ...parentNoScopeSet]);
 
   function initialize() {
-    const scope = createScope(atoms, parentScope, debugName);
+    const scope = createScope(atoms, noScopeSet, parentScope, debugName);
     return {
       patchedStore: createPatchedStore(baseStore, scope),
-      scopeContext: { scope, baseStore },
+      scopeContext: { scope, baseStore, noScopeSet },
       hasChanged(current: {
-        baseStore: Store;
         parentScope: Scope | undefined;
+        baseStore: Store;
         atomSet: Set<AnyAtom>;
+        noScopeSet: Set<AnyAtom>;
       }) {
         return (
           parentScope !== current.parentScope ||
+          current.baseStore !== baseStore ||
           !isEqualSet(atomSet, current.atomSet) ||
-          current.baseStore !== baseStore
+          !isEqualSet(noScopeSet, current.noScopeSet)
         );
       },
     };
@@ -53,7 +63,7 @@ export const ScopeProvider = ({
 
   const [state, setState] = useState(initialize);
   const { hasChanged, scopeContext, patchedStore } = state;
-  if (hasChanged({ parentScope, atomSet, baseStore })) {
+  if (hasChanged({ parentScope, baseStore, atomSet, noScopeSet })) {
     setState(initialize);
   }
   return (


### PR DESCRIPTION
## Background
Unscoped derived atoms must be copied in a scope in case they depend on atoms that are scoped. This copy causes read side-effects such as fetch to rerun which may be undesirable. There is no way for developers to indicate that a derived atom does not depend on scoped atoms in the current api.

## Proposed Solution
This PR proposes a new prop for ScopeProvider, `noScope: Iterable<AnyAtom>`. Passing atoms to this prop will declare them to be not dependent on any scoped atoms.

```jsx
<ScopeProvider atoms={[]} noScope={[atomA]}>
```

## Behavior
1. ❌ If an atom is unscoped (derived, primitive, or writeOnly) and noScoped, it will NOT be cloned.
1. ❌ If an atom is inherited from a scoped atom and noScoped, it will NOT be cloned.
1. ✅ If an atom is explicitly scoped and noScoped, it will still be cloned.
1. ✅ If an atom is implicitly scoped and noScoped, it will still be cloned.

## Fixes:
 - https://github.com/jotaijs/jotai-scope/issues/25

## Discussion
### 1. Should we instead export a utility to set this globally?
I think I'm still in favor of a noScope property on the ScopeProvider as it provides greater specificity.
```ts
export function noScope(anAtom: AnyAtom) {
  anAtom.noScope = true;
}
```

### 2. Should implicit dependencies adhere to noScope?
Should atomA be implicit scoped in the following example?
```jsx
const atomA = atom(() => fetch(url))
const atomB = atom((get) => get(atomA))

function Component() {
  useAtom(atomB)
}

<ScopeProvider atoms={[atomB]} noScope={[atomA]}>
  <Component />
</ScopeProvider>
```

### 3. 💡 Another idea
Jotai exposes an api that describes the atom's current dependencies and notifies when dependencies change. Jotai Scope will determine if any of those dependencies are scoped to determine whether the atom needs to be copied or not.

### 4. 💡 Yet another idea
An atom's Getter and Setter are defined by the store and can be overwritten by jotai-scope. This eliminates the for copying unscoped derived atoms.
