### PR TITLE
fix ScopeProvider error for polyfill

### DIFF
--- a/__tests__/ScopeProvider/01_basic_spec.tsx
+++ b/__tests__/ScopeProvider/01_basic_spec.tsx
@@ -4,8 +4,8 @@ import {
   useSetAtom,
   useAtomValue,
   atom,
-  WritableAtom,
-  SetStateAction,
+  type WritableAtom,
+  type SetStateAction,
 } from 'jotai';
 import { atomWithReducer } from 'jotai/vanilla/utils';
 import { ScopeProvider } from '../../src/index';

--- a/__tests__/ScopeProvider/02_removeScope.tsx
+++ b/__tests__/ScopeProvider/02_removeScope.tsx
@@ -1,5 +1,5 @@
 import { render } from '@testing-library/react';
-import { PropsWithChildren } from 'react';
+import type { PropsWithChildren } from 'react';
 import { atom, useAtom, useAtomValue } from 'jotai';
 import { atomWithReducer } from 'jotai/vanilla/utils';
 import { ScopeProvider } from '../../src/index';

--- a/__tests__/ScopeProvider/06_implicit_parent.tsx
+++ b/__tests__/ScopeProvider/06_implicit_parent.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import type { FC } from 'react';
 import { render } from '@testing-library/react';
 import { atom, useAtom, useAtomValue } from 'jotai';
 import { atomWithReducer } from 'jotai/vanilla/utils';

--- a/__tests__/ScopeProvider/09_scope_provider.tsx
+++ b/__tests__/ScopeProvider/09_scope_provider.tsx
@@ -1,0 +1,47 @@
+import { useState } from 'react';
+import { render, act } from '@testing-library/react';
+import { atom, useAtomValue } from 'jotai';
+import { ScopeProvider } from '../../src/index';
+import { clickButton } from '../utils';
+
+describe('ScopeProvider', () => {
+  it('mounts and unmounts successfully', () => {
+    const baseAtom = atom(0);
+    function Component() {
+      const base = useAtomValue(baseAtom);
+      return <div className="base">{base}</div>;
+    }
+    function App() {
+      const [isMounted, setIsMounted] = useState(false);
+      return (
+        <>
+          <div>
+            <button
+              className="mount"
+              type="button"
+              onClick={() => setIsMounted((t) => !t)}
+            >
+              Mount
+            </button>
+          </div>
+          {isMounted && (
+            <ScopeProvider atoms={[baseAtom]}>
+              <Component />
+            </ScopeProvider>
+          )}
+        </>
+      );
+    }
+    const { unmount, container } = render(<App />);
+    const mountButton = '.mount';
+    const base = '.base';
+
+    act(() => clickButton(container, mountButton));
+    expect(container.querySelector(base)).not.toBe(null);
+    act(() => clickButton(container, mountButton));
+    expect(container.querySelector(base)).toBe(null);
+    act(() => clickButton(container, mountButton));
+    unmount();
+    expect(container.querySelector(base)).toBe(null);
+  });
+});

--- a/src/ScopeProvider/scope.ts
+++ b/src/ScopeProvider/scope.ts
@@ -78,7 +78,7 @@ export function createScope(
   }
   currentScope.cleanup = combineVoidFunctions(
     currentScope.cleanup,
-    ...cleanupFamiliesSet,
+    ...Array.from(cleanupFamiliesSet),
   );
 
   /**


### PR DESCRIPTION
```ts
const cleanupFamiliesSet = new Set<() => void>();
...
currentScope.cleanup = combineVoidFunctions(
  currentScope.cleanup,
  ...cleanupFamiliesSet,
);
```
The above code polyfills to
```ts
currentScope.cleanup = combineVoidFunctions.apply(void 0, [currentScope.cleanup].concat(cleanupFamiliesSet));
```

This is not correct and leads to arguments being `[() => {}, new Set()]`.
Whereas expected is `[() => {}]`.

The solution is to wrap the set with `Array.from`.

```ts
const cleanupFamiliesSet = new Set<() => void>();
...
currentScope.cleanup = combineVoidFunctions(
  currentScope.cleanup,
  ...Array.from(cleanupFamiliesSet),
);
```

Tests are not catching this issue either.