### PR TITLE
Fix scoped writables

### DIFF
--- a/src/ScopeProvider/patchedStore.ts
+++ b/src/ScopeProvider/patchedStore.ts
@@ -14,7 +14,12 @@ export function createPatchedStore(baseStore: Store, scope: Scope): Store {
     },
     set(anAtom, ...args) {
       const [scopedAtom, implicitScope] = scope.getAtom(anAtom)
-      const restore = scope.prepareWriteAtom(scopedAtom, anAtom, implicitScope)
+      const restore = scope.prepareWriteAtom(
+        scopedAtom,
+        anAtom,
+        implicitScope,
+        scope
+      )
       try {
         return baseStore.set(scopedAtom, ...args)
       } finally {

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,7 +30,8 @@ export type Scope = {
   prepareWriteAtom: <T extends AnyAtom>(
     anAtom: T,
     originalAtom: T,
-    implicitScope?: Scope
+    implicitScope?: Scope,
+    writeScope?: Scope
   ) => (() => void) | undefined
 
   /**

--- a/tests/issues.test.ts
+++ b/tests/issues.test.ts
@@ -1,0 +1,80 @@
+import { atom, createStore } from 'jotai'
+import { describe, expect, it, vi } from 'vitest'
+import { createPatchedStore } from '../src/ScopeProvider/patchedStore'
+import { createScope } from '../src/ScopeProvider/scope'
+
+describe('open issues', () => {
+  // FIXME:
+  it.fails('https://github.com/jotaijs/jotai-scope/issues/25', () => {
+    const a = atom(vi.fn(), () => {})
+    a.debugLabel = 'atomA'
+    a.onMount = vi.fn()
+
+    const s0 = createStore()
+    s0.sub(a, () => {
+      console.log('S0: atomA changed')
+    })
+
+    const s1 = createPatchedStore(
+      s0,
+      createScope(
+        ...(Object.values({
+          atoms: new Set([a]),
+          atomFamilies: new Set(),
+          parentScope: undefined,
+          scopeName: 's1',
+        }) as Parameters<typeof createScope>)
+      )
+    )
+
+    s1.sub(a, () => {
+      console.log('S1: atomA changed')
+    })
+
+    expect(a.read).toHaveBeenCalledTimes(1)
+    expect(a.onMount).toHaveBeenCalledTimes(1)
+  })
+
+  it('https://github.com/jotaijs/jotai-scope/issues/62', () => {
+    const a = atom(0)
+    a.debugLabel = 'atomA'
+
+    const b = atom(null, (_, set, value: number) => {
+      set(a, value)
+    })
+    b.debugLabel = 'atomB'
+
+    const c = atom(null, (_, set, value: number) => {
+      set(b, value)
+    })
+    c.debugLabel = 'atomC'
+
+    function createStores() {
+      const s0Store = createStore()
+      s0Store.sub(a, () => {
+        console.log('S1', s0Store.get(a))
+      })
+
+      const s1Store = createPatchedStore(
+        s0Store,
+        createScope(
+          ...(Object.values({
+            atoms: new Set([a]),
+            atomFamilies: new Set(),
+            parentScope: undefined,
+            scopeName: 's1',
+          }) as Parameters<typeof createScope>)
+        )
+      )
+      s1Store.sub(a, () => {
+        console.log('S1', s1Store.get(a))
+      })
+      return { s0Store, s1Store }
+    }
+    {
+      const { s0Store, s1Store } = createStores()
+      s1Store.set(c, 1)
+      expect([s0Store.get(a), s1Store.get(a)] + '').toEqual('0,1')
+    }
+  })
+})


### PR DESCRIPTION
## Summary
Fixes: https://github.com/jotaijs/jotai-scope/issues/62

The original implementation patched only the top-level writable atom. This change applies this patch recursively down to enable writable atoms.