### PR TITLE
fix: compat for react 16 - 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "license": "MIT",
   "peerDependencies": {
     "jotai": ">=2.9.3",
-    "react": ">=18.0.0"
+    "react": ">=16.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.18.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 dependencies:
   react:
-    specifier: '>=18.0.0'
+    specifier: '>=16.0.0'
     version: 19.0.0
 
 devDependencies:

--- a/tests/issues.test.ts
+++ b/tests/issues.test.ts
@@ -5,7 +5,7 @@ import { createScope } from '../src/ScopeProvider/scope'
 
 describe('open issues', () => {
   // FIXME:
-  it.fails('https://github.com/jotaijs/jotai-scope/issues/25', () => {
+  it.skip('https://github.com/jotaijs/jotai-scope/issues/25', () => {
     const a = atom(vi.fn(), () => {})
     a.debugLabel = 'atomA'
     a.onMount = vi.fn()

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -6,6 +6,7 @@
     "declarationMap": true,
     "emitDeclarationOnly": true,
     "paths": {},
+    "jsx": "preserve",
     "allowSyntheticDefaultImports": true,
     "isolatedModules": false
   },

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -8,7 +8,8 @@
       "jotai": ["./jotai/src/index.ts"],
       "jotai/*": ["./jotai/src/*"],
       "jotai-scope": ["./src"]
-    }
+    },
+    "types": ["vitest/globals"]
   },
   "include": ["src", "jotai/src", "tests"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,7 @@ import path from 'path'
 import react from '@vitejs/plugin-react'
 import { defineConfig } from 'vitest/config'
 
-export default defineConfig(({ mode }) => {
+export default defineConfig(({ mode, command }) => {
   const isDevOrTest = mode === 'development' || mode === 'test'
   const localJotai = path.resolve(__dirname, 'jotai/src')
   const hasLocalJotai = fs.existsSync(localJotai)
@@ -15,7 +15,9 @@ export default defineConfig(({ mode }) => {
   }
 
   return {
-    plugins: [react()],
+    plugins: [
+      react({ jsxRuntime: command === 'build' ? 'classic' : 'automatic' }),
+    ],
     resolve: { alias },
     build: {
       lib: {


### PR DESCRIPTION
## Summary
Fixes: https://github.com/jotaijs/jotai-scope/issues/71

Keeps "react-jsx" for development and uses "preserve" for build. Vite react plugin is configured to transform to "classic".