### PR TITLE
feat: support atom defaults in ScopeProvider and update README

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,13 +1,13 @@
 import type { Atom, WritableAtom, createStore } from 'jotai/vanilla'
-import { AtomFamily } from 'jotai/vanilla/utils/atomFamily'
+import type { AtomFamily } from 'jotai/vanilla/utils/atomFamily'
 
 export type Store = ReturnType<typeof createStore>
 
-export type AnyAtom = Atom<unknown> | WritableAtom<unknown, unknown[], unknown>
+export type AnyAtom = Atom<any> | AnyWritableAtom
 
-export type AnyAtomFamily = AtomFamily<unknown, AnyAtom>
+export type AnyAtomFamily = AtomFamily<any, AnyAtom>
 
-export type AnyWritableAtom = WritableAtom<unknown, unknown[], unknown>
+export type AnyWritableAtom = WritableAtom<any, any[], any>
 
 export type Scope = {
   /**
@@ -44,3 +44,5 @@ export type Scope = {
    */
   toString?: () => string
 }
+
+export type AtomDefault = readonly [AnyWritableAtom, unknown]

--- a/tests/ScopeProvider/10_atom_defaults.test.tsx
+++ b/tests/ScopeProvider/10_atom_defaults.test.tsx
@@ -1,0 +1,57 @@
+import { render } from '@testing-library/react'
+import { atom, useAtomValue } from 'jotai'
+import { describe, expect, test, vi } from 'vitest'
+import { ScopeProvider } from 'jotai-scope'
+
+describe('ScopeProvider atom defaults', () => {
+  test('atoms defaults are applied without an extra render', () => {
+    const a = atom(0)
+    const b = atom(0)
+    const c = atom(0)
+    a.debugLabel = 'a'
+    b.debugLabel = 'b'
+    c.debugLabel = 'c'
+    const Component = vi.fn(() => (
+      <>
+        <div className="a">{useAtomValue(a)}</div>
+        <div className="b">{useAtomValue(b)}</div>
+        <div className="c">{useAtomValue(c)}</div>
+      </>
+    ))
+    function getValues(container: HTMLElement) {
+      return String(
+        ['a', 'b', 'c'].map(
+          (className) => container.querySelector(`.${className}`)!.textContent
+        )
+      )
+    }
+    {
+      // without defaults
+      const { container } = render(
+        <ScopeProvider debugName="withoutDefaults" atoms={[a, b]}>
+          <Component />
+        </ScopeProvider>
+      )
+      expect(getValues(container)).toBe('0,0,0')
+      expect(Component).toHaveBeenCalledTimes(2)
+    }
+    vi.clearAllMocks()
+    {
+      // with defaults
+      const { container } = render(
+        <ScopeProvider
+          debugName="withDefaults"
+          atoms={[
+            [a, 1],
+            [b, 2],
+          ]}>
+          <Component />
+        </ScopeProvider>
+      )
+      expect(getValues(container)).toBe('1,2,0')
+      // Component is normally rendered twice,
+      // adding defaults does not add an extra render
+      expect(Component).toHaveBeenCalledTimes(2)
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- Support providing default values for scoped atoms. (Fixes: https://github.com/jotaijs/jotai-scope/issues/63)
- Updates readme with more examples and a section on createIsolation. (Fixes: https://github.com/jotaijs/jotai-scope/issues/64 and https://github.com/jotaijs/jotai-scope/issues/70)

```tsx
<ScopeProvider atoms={[[countAtom, 42]]}>
  <Counter />   {/* starts at 42 inside this scope, yay! */}
</ScopeProvider>
```