### PR TITLE
[WIP] Refactor to use the new jotai store exposed internal methods (Attempt 11)

### DIFF
--- a/src/ScopeProvider/ScopeProvider.tsx
+++ b/src/ScopeProvider/ScopeProvider.tsx
@@ -1,14 +1,10 @@
 import { type PropsWithChildren, useEffect, useState } from 'react'
 import { Provider, useStore } from 'jotai/react'
 import { useHydrateAtoms } from 'jotai/utils'
-import {
-  type AnyAtom,
-  type AnyAtomFamily,
-  type AtomDefault,
-  SCOPE,
-  ScopedStore,
-  type Store,
-} from '../types'
+import type { INTERNAL_Store as Store } from 'jotai/vanilla/internals'
+import type { AnyAtom, AnyAtomFamily, AtomDefault, ScopedStore } from '../types'
+import { SCOPE } from '../types'
+import { isEqualSet } from '../utils'
 import { createScope } from './scope'
 
 type ScopeProviderBaseProps = PropsWithChildren<{
@@ -83,8 +79,4 @@ export function ScopeProvider({
   )
   useEffect(() => scopedStore[SCOPE].cleanup, [scopedStore])
   return <Provider store={scopedStore}>{children}</Provider>
-}
-
-function isEqualSet(a: Set<unknown>, b: Set<unknown>) {
-  return a === b || (a.size === b.size && Array.from(a).every(b.has.bind(b)))
 }

--- a/src/createIsolation.tsx
+++ b/src/createIsolation.tsx
@@ -8,7 +8,8 @@ import {
 } from 'jotai/react'
 import { useHydrateAtoms } from 'jotai/react/utils'
 import { createStore } from 'jotai/vanilla'
-import type { AnyWritableAtom, Store } from './types'
+import { INTERNAL_Store as Store } from 'jotai/vanilla/internals'
+import type { AnyWritableAtom } from './types'
 
 type CreateIsolationResult = {
   Provider: (props: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,11 +1,11 @@
-import type { Atom, WritableAtom, createStore } from 'jotai/vanilla'
+import type { Atom, WritableAtom } from 'jotai/vanilla'
+import {
+  INTERNAL_getBuildingBlocksRev1 as INTERNAL_getBuildingBlocks,
+  INTERNAL_Store as Store,
+} from 'jotai/vanilla/internals'
 import type { AtomFamily } from 'jotai/vanilla/utils/atomFamily'
 
-export type Store = ReturnType<typeof createStore>
-
-export type ScopedStore = Store & {
-  [SCOPE]: Scope
-}
+export type ScopedStore = Store & { [SCOPE]: Scope }
 
 export type AnyAtom = Atom<any> | AnyWritableAtom
 
@@ -53,6 +53,21 @@ export const SCOPE = Symbol('scope')
 
 export type AtomDefault = readonly [AnyWritableAtom, unknown]
 
-export type WithOriginal<T extends AnyAtom> = T & {
-  originalAtom: T
+export type CloneAtom<T extends AnyAtom> = T & {
+  /** original atom */
+  o: T
+  /** clone type */
+  x: EXPLICIT | CONSUMER | undefined
 }
+
+export const EXPLICIT = Symbol('explicit')
+export const CONSUMER = Symbol('consumer')
+export type EXPLICIT = typeof EXPLICIT
+export type CONSUMER = typeof CONSUMER
+
+type Mutable<T> = {
+  -readonly [K in keyof T]: T[K]
+}
+export type BuildingBlocks = Partial<
+  Mutable<ReturnType<typeof INTERNAL_getBuildingBlocks>>
+>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,9 @@
+import { AnyAtom, CloneAtom } from './types'
+
+export function isCloneAtom<T extends AnyAtom>(atom: T): atom is CloneAtom<T> {
+  return 'o' in atom && 'x' in atom
+}
+
+export function isEqualSet(a: Set<unknown>, b: Set<unknown>) {
+  return a === b || (a.size === b.size && Array.from(a).every(b.has.bind(b)))
+}

--- a/tests/issues.test.ts
+++ b/tests/issues.test.ts
@@ -4,7 +4,9 @@ import { createScope } from '../src/ScopeProvider/scope'
 
 describe('open issues', () => {
   // FIXME:
-  it.skip('https://github.com/jotaijs/jotai-scope/issues/25', () => {
+  it.only('https://github.com/jotaijs/jotai-scope/issues/25', () => {
+    // is not scoped, so it only be computed once
+    // even if it's read from multiple scopes
     const a = atom(
       vi.fn(() => {
         console.log('reading atomA')
@@ -21,8 +23,11 @@ describe('open issues', () => {
       console.log('S0: atomA changed')
     })
 
+    expect(a.read).toHaveBeenCalledTimes(1)
+    expect(a.onMount).toHaveBeenCalledTimes(1)
+
     const s1 = createScope({
-      atomSet: new Set([a]),
+      atomSet: new Set([]),
       atomFamilySet: new Set(),
       parentStore: s0,
       scopeName: 's1',

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,5 +1,5 @@
 import { fireEvent } from '@testing-library/react'
-import { Store } from 'src/types'
+import { INTERNAL_Store as Store } from 'jotai/vanilla/internals'
 
 function getElements(
   container: HTMLElement,
@@ -39,7 +39,7 @@ type DevStoreRev4 = Omit<
 
 export function getDevStore(store: Store): PrdStore & DevStoreRev4 {
   if (!isDevStore(store)) {
-    throw new Error('Store is not a dev store')
+    throw new Error('INTERNAL_Store is not a dev store')
   }
   return store
 }
@@ -56,7 +56,7 @@ export function assertIsDevStore(
   store: Store
 ): asserts store is PrdStore & DevStoreRev4 {
   if (!isDevStore(store)) {
-    throw new Error('Store is not a dev store')
+    throw new Error('INTERNAL_Store is not a dev store')
   }
 }
 


### PR DESCRIPTION
## Summary
In Jotai, reactive state is an atom + a store. To scope a value, we can either clone the atom or replace the store. Replacing the store has its own complexities but could be a viable long-term solution. For now, we will continue with the approach that clones atoms. For this to work, we need to ensure that unscoped derived atoms do not needlessly recompute.

Derived atoms that are not explicitly scoped or inherited can either be unscoped or *consumer* atoms.

To differentiate between consumer and unscoped atoms, we  use the following piece of information.
*consumer* atoms are atoms that read:
  1. explicit scoped atoms
  2. other consumer atoms (besides self)
  3. inherited explicit atoms
  4. inherited consumer atoms

Before a consumer atom has first been read, we cannot yet determine whether it is a consumer atom or not. This is currently an _UNSOLVED PROBLEM_.

## Goal
*unscoped* atoms should _not_ recompute in separate scopes.

The new code should address https://github.com/jotaijs/jotai-scope/issues/25 and https://github.com/jotaijs/jotai-scope/issues/36.

## TODO
1. figure out how determine a consumer atom on first read. Idea: determine this in flushPending to decide whether to notify listeners. Note: this would not address the atomWithObservable bug as that atom has a side-effect in the read function.

2. fix tests

3. fix INF loop with getAtom for nested scope providers.

## Open Questions
1. Should all scopes share invalidatedAtoms, changedAtoms, and storeHooks?
