### PR TITLE
fix: nextjs compatibility

### DIFF
--- a/src/ScopeProvider/ScopeProvider.tsx
+++ b/src/ScopeProvider/ScopeProvider.tsx
@@ -1,4 +1,9 @@
-import { type PropsWithChildren, useEffect, useState } from 'react'
+import {
+  type PropsWithChildren,
+  createElement,
+  useEffect,
+  useState,
+} from 'react'
 import { Provider, useStore } from 'jotai/react'
 import { useHydrateAtoms } from 'jotai/utils'
 import {
@@ -82,7 +87,7 @@ export function ScopeProvider({
     { store: scopedStore }
   )
   useEffect(() => scopedStore[SCOPE].cleanup, [scopedStore])
-  return <Provider store={scopedStore}>{children}</Provider>
+  return createElement(Provider, { store: scopedStore }, children)
 }
 
 function isEqualSet(a: Set<unknown>, b: Set<unknown>) {

--- a/src/createIsolation.tsx
+++ b/src/createIsolation.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useRef } from 'react'
+import { createContext, createElement, useContext, useRef } from 'react'
 import type { ReactNode } from 'react'
 import {
   useAtom as useAtomOrig,
@@ -39,11 +39,10 @@ export function createIsolation(): CreateIsolationResult {
       storeRef.current = createStore()
     }
     useHydrateAtoms(initialValues as any, { store: storeRef.current })
-    return (
-      <StoreContext.Provider value={storeRef.current}>
-        {children}
-      </StoreContext.Provider>
-    )
+    return createElement(StoreContext.Provider, {
+      value: storeRef.current,
+      children,
+    })
   }
 
   const useStore = ((options?: any) => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,21 +3,17 @@ import path from 'path'
 import react from '@vitejs/plugin-react'
 import { defineConfig } from 'vitest/config'
 
-export default defineConfig(({ mode, command }) => {
-  const isDevOrTest = mode === 'development' || mode === 'test'
+export default defineConfig(({ mode }) => {
   const localJotai = path.resolve(__dirname, 'jotai/src')
   const hasLocalJotai = fs.existsSync(localJotai)
-  const alias = {
-    'jotai-scope': path.resolve(__dirname, 'src'),
-  }
-  if (isDevOrTest && hasLocalJotai) {
+  const alias = {}
+  if ((mode === 'development' || mode === 'test') && hasLocalJotai) {
     alias['jotai'] = localJotai
+    alias['jotai-scope'] = path.resolve(__dirname, 'src')
   }
 
   return {
-    plugins: [
-      react({ jsxRuntime: command === 'build' ? 'classic' : 'automatic' }),
-    ],
+    plugins: [react()],
     resolve: { alias },
     build: {
       lib: {


### PR DESCRIPTION
## Summary
In adding support for react 16-17, the change broke compatibility with nextjs.

Fixes: https://github.com/jotaijs/jotai-scope/issues/82

### What Changed
The previous change uses vite to automatically add React to jsx src files.

### Why did this break NextJS?
Nextjs does not use vite to build. This caused build files to be missing a reference to React.

### What was the fix
Replace jsx with createElement.