### PR TITLE
jotai-effect compat for jotai@2.14.0 #89

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ jotai
 jotai-effect
 node_modules
 .DS_Store
+
+# Generated JavaScript files from TypeScript compilation
+src/**/*.js
+src/**/*.js.map

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "eslint-plugin-prettier": "^5.2.3",
     "happy-dom": "^15.11.7",
     "jiti": "^2.4.2",
-    "jotai": "2.14.0",
+    "jotai": "https://pkg.csb.dev/pmndrs/jotai/commit/12214901/jotai",
     "jotai-effect": "2.1.0",
     "prettier": "^3.4.2",
     "typescript": "^5.7.2",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "jotai": ">=2.14.0",
+    "jotai": ">=2.15.0",
     "react": ">=16.0.0"
   },
   "devDependencies": {
@@ -71,8 +71,8 @@
     "eslint-plugin-prettier": "^5.2.3",
     "happy-dom": "^15.11.7",
     "jiti": "^2.4.2",
-    "jotai": "https://pkg.csb.dev/pmndrs/jotai/commit/12214901/jotai",
-    "jotai-effect": "2.1.0",
+    "jotai": "2.15.0",
+    "jotai-effect": "2.1.2",
     "prettier": "^3.4.2",
     "typescript": "^5.7.2",
     "typescript-eslint": "^8.21.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,8 +56,8 @@ devDependencies:
     specifier: ^2.4.2
     version: 2.4.2
   jotai:
-    specifier: 2.14.0
-    version: 2.14.0(@babel/core@7.26.0)(@types/react@19.0.8)(react@19.0.0)
+    specifier: https://pkg.csb.dev/pmndrs/jotai/commit/12214901/jotai
+    version: '@pkg.csb.dev/pmndrs/jotai/commit/12214901/jotai(@babel/core@7.26.0)(@types/react@19.0.8)(react@19.0.0)'
   jotai-effect:
     specifier: 2.1.0
     version: 2.1.0(jotai@2.14.0)
@@ -2594,30 +2594,7 @@ packages:
     peerDependencies:
       jotai: '>=2.12.1'
     dependencies:
-      jotai: 2.14.0(@babel/core@7.26.0)(@types/react@19.0.8)(react@19.0.0)
-    dev: true
-
-  /jotai@2.14.0(@babel/core@7.26.0)(@types/react@19.0.8)(react@19.0.0):
-    resolution: {integrity: sha512-JQkNkTnqjk1BlSUjHfXi+pGG/573bVN104gp6CymhrWDseZGDReTNniWrLhJ+zXbM6pH+82+UNJ2vwYQUkQMWQ==}
-    engines: {node: '>=12.20.0'}
-    peerDependencies:
-      '@babel/core': '>=7.0.0'
-      '@babel/template': '>=7.0.0'
-      '@types/react': '>=17.0.0'
-      react: '>=17.0.0'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      '@babel/template':
-        optional: true
-      '@types/react':
-        optional: true
-      react:
-        optional: true
-    dependencies:
-      '@babel/core': 7.26.0
-      '@types/react': 19.0.8
-      react: 19.0.0
+      jotai: '@pkg.csb.dev/pmndrs/jotai/commit/12214901/jotai(@babel/core@7.26.0)(@types/react@19.0.8)(react@19.0.0)'
     dev: true
 
   /js-tokens@4.0.0:
@@ -3699,4 +3676,30 @@ packages:
   /yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+    dev: true
+
+  '@pkg.csb.dev/pmndrs/jotai/commit/12214901/jotai(@babel/core@7.26.0)(@types/react@19.0.8)(react@19.0.0)':
+    resolution: {tarball: https://pkg.csb.dev/pmndrs/jotai/commit/12214901/jotai}
+    id: '@pkg.csb.dev/pmndrs/jotai/commit/12214901/jotai'
+    name: jotai
+    version: 2.14.0
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@babel/core': '>=7.0.0'
+      '@babel/template': '>=7.0.0'
+      '@types/react': '>=17.0.0'
+      react: '>=17.0.0'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      '@babel/template':
+        optional: true
+      '@types/react':
+        optional: true
+      react:
+        optional: true
+    dependencies:
+      '@babel/core': 7.26.0
+      '@types/react': 19.0.8
+      react: 19.0.0
     dev: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,11 +56,11 @@ devDependencies:
     specifier: ^2.4.2
     version: 2.4.2
   jotai:
-    specifier: https://pkg.csb.dev/pmndrs/jotai/commit/12214901/jotai
-    version: '@pkg.csb.dev/pmndrs/jotai/commit/12214901/jotai(@babel/core@7.26.0)(@types/react@19.0.8)(react@19.0.0)'
+    specifier: 2.15.0
+    version: 2.15.0(@babel/core@7.26.0)(@types/react@19.0.8)(react@19.0.0)
   jotai-effect:
-    specifier: 2.1.0
-    version: 2.1.0(jotai@2.14.0)
+    specifier: 2.1.2
+    version: 2.1.2(jotai@2.15.0)
   prettier:
     specifier: ^3.4.2
     version: 3.4.2
@@ -2588,13 +2588,36 @@ packages:
     hasBin: true
     dev: true
 
-  /jotai-effect@2.1.0(jotai@2.14.0):
-    resolution: {integrity: sha512-1nD6D4JizwCH3z2kun71ZUkxeeE5PknUkuP98NqQdCanidct2BHIhSwRxnfA0C2CPAn9H+5NF0EHU6gPkdhh7Q==}
+  /jotai-effect@2.1.2(jotai@2.15.0):
+    resolution: {integrity: sha512-TDofNDeRENGVM0KzW6fgqvshFCkkXliaiWE7MvbfysEJqVJKW20P3LZ0BoqqqpA2mPvgHylac6V5O26l4ib/jg==}
     engines: {node: '>=12.20.0'}
     peerDependencies:
-      jotai: '>=2.12.1'
+      jotai: '>=2.14.0'
     dependencies:
-      jotai: '@pkg.csb.dev/pmndrs/jotai/commit/12214901/jotai(@babel/core@7.26.0)(@types/react@19.0.8)(react@19.0.0)'
+      jotai: 2.15.0(@babel/core@7.26.0)(@types/react@19.0.8)(react@19.0.0)
+    dev: true
+
+  /jotai@2.15.0(@babel/core@7.26.0)(@types/react@19.0.8)(react@19.0.0):
+    resolution: {integrity: sha512-nbp/6jN2Ftxgw0VwoVnOg0m5qYM1rVcfvij+MZx99Z5IK13eGve9FJoCwGv+17JvVthTjhSmNtT5e1coJnr6aw==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@babel/core': '>=7.0.0'
+      '@babel/template': '>=7.0.0'
+      '@types/react': '>=17.0.0'
+      react: '>=17.0.0'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      '@babel/template':
+        optional: true
+      '@types/react':
+        optional: true
+      react:
+        optional: true
+    dependencies:
+      '@babel/core': 7.26.0
+      '@types/react': 19.0.8
+      react: 19.0.0
     dev: true
 
   /js-tokens@4.0.0:
@@ -3676,30 +3699,4 @@ packages:
   /yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
-    dev: true
-
-  '@pkg.csb.dev/pmndrs/jotai/commit/12214901/jotai(@babel/core@7.26.0)(@types/react@19.0.8)(react@19.0.0)':
-    resolution: {tarball: https://pkg.csb.dev/pmndrs/jotai/commit/12214901/jotai}
-    id: '@pkg.csb.dev/pmndrs/jotai/commit/12214901/jotai'
-    name: jotai
-    version: 2.14.0
-    engines: {node: '>=12.20.0'}
-    peerDependencies:
-      '@babel/core': '>=7.0.0'
-      '@babel/template': '>=7.0.0'
-      '@types/react': '>=17.0.0'
-      react: '>=17.0.0'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      '@babel/template':
-        optional: true
-      '@types/react':
-        optional: true
-      react:
-        optional: true
-    dependencies:
-      '@babel/core': 7.26.0
-      '@types/react': 19.0.8
-      react: 19.0.0
     dev: true

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
 export { createIsolation } from './createIsolation'
 export { ScopeProvider } from './ScopeProvider/ScopeProvider'
-export { scope as createScope } from './ScopeProvider/scope'
+export { createScope } from './ScopeProvider/scope'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
 export { createIsolation } from './createIsolation'
 export { ScopeProvider } from './ScopeProvider/ScopeProvider'
-export { createScope } from './ScopeProvider/scope'
+export { scope as createScope } from './ScopeProvider/scope'

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,7 +6,7 @@ import type {
 } from 'jotai/vanilla/internals'
 import type { AtomFamily } from 'jotai/vanilla/utils/atomFamily'
 
-export type ScopedStore = Store & { [SCOPE]: Scope }
+export type ScopedStore = Store
 
 export type AnyAtom = Atom<any> | AnyWritableAtom
 
@@ -40,6 +40,11 @@ export type Scope = {
   ) => (() => void) | undefined
 
   /**
+   * The base store (unpatched) that this scope is built on
+   */
+  baseStore: Store
+
+  /**
    * @debug
    */
   name?: string
@@ -50,7 +55,10 @@ export type Scope = {
   toString?: () => string
 }
 
-export const SCOPE = Symbol('scope')
+/**
+ * WeakMap to store the scope associated with each scoped store
+ */
+export const storeScopeMap = new WeakMap<Store, Scope>()
 
 export type AtomDefault = readonly [AnyWritableAtom, unknown]
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,15 +1,12 @@
 import { type Atom, type WritableAtom } from 'jotai'
 import type {
-  INTERNAL_BuildingBlocks,
-  INTERNAL_ChangedAtoms,
+  INTERNAL_ChangedAtoms as ChangedAtoms,
   INTERNAL_StoreHooks,
   INTERNAL_Store as Store,
 } from 'jotai/vanilla/internals'
 import type { AtomFamily } from 'jotai/vanilla/utils/atomFamily'
 
-export type ScopedStore = Store & {
-  [SCOPE]: Scope
-}
+export type ScopedStore = Store & { [SCOPE]: Scope }
 
 export type AnyAtom = Atom<any> | AnyWritableAtom
 
@@ -63,13 +60,11 @@ export type WithOriginal<T extends AnyAtom> = T & {
 
 type Mutable<T> = { -readonly [P in keyof T]: T[P] }
 
-export type BuildingBlocks = Mutable<INTERNAL_BuildingBlocks>
-
 export type StoreHooks = Mutable<Required<INTERNAL_StoreHooks>>
 
 export type StoreHookForAtoms = StoreHooks['c']
 
-export type WeakSetForAtoms = INTERNAL_ChangedAtoms
+export type WeakSetForAtoms = ChangedAtoms
 
 export type WeakMapForAtoms = {
   get(atom: AnyAtom): any

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,14 @@
 import type { AnyAtom, AnyWritableAtom } from './types'
 
-export function isEqualSet(a: Set<unknown>, b: Set<unknown>) {
-  return a === b || (a.size === b.size && Array.from(a).every(b.has.bind(b)))
+export function isEqualSize(
+  aIter: Iterable<unknown>,
+  bIter: Iterable<unknown>
+) {
+  const a = new Set(aIter)
+  const b = new Set(bIter)
+  return (
+    aIter === bIter || (a.size === b.size && Array.from(a).every(b.has.bind(b)))
+  )
 }
 
 export function toNameString(this: { name: string }) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,32 +1,7 @@
-import { INTERNAL_getBuildingBlocksRev2 as getBuildingBlocks } from 'jotai/vanilla/internals'
-import type { INTERNAL_Store as Store } from 'jotai/vanilla/internals'
-import type {
-  AnyAtom,
-  AnyWritableAtom,
-  BuildingBlocks,
-  ScopedStore,
-} from './types'
+import type { AnyAtom, AnyWritableAtom } from './types'
 
 export function isEqualSet(a: Set<unknown>, b: Set<unknown>) {
   return a === b || (a.size === b.size && Array.from(a).every(b.has.bind(b)))
-}
-
-const originalBuildingBlocks = new WeakMap<
-  Store | ScopedStore,
-  BuildingBlocks
->()
-
-export function setOriginalBuildingBlocks(
-  store: Store | ScopedStore,
-  buildingBlocks: BuildingBlocks
-) {
-  originalBuildingBlocks.set(store, buildingBlocks)
-}
-
-export function getBaseStoreState(store: Store | ScopedStore): BuildingBlocks {
-  return [
-    ...(originalBuildingBlocks.get(store) ?? getBuildingBlocks(store)),
-  ] as BuildingBlocks
 }
 
 export function toNameString(this: { name: string }) {

--- a/tests/ScopeProvider/03_nested.test.tsx
+++ b/tests/ScopeProvider/03_nested.test.tsx
@@ -60,14 +60,14 @@ function App() {
       <Counter counterClass="unscoped" />
       <h1>Layer 1: Scope base 1</h1>
       <p>base 2 and base should be globally shared</p>
-      <ScopeProvider atoms={[baseAtom1]}>
+      <ScopeProvider atoms={[baseAtom1]} name="layer1">
         <Counter counterClass="layer1" />
         <h1>Layer 2: Scope base 2</h1>
         <p>
           base 1 should be shared between layer 1 and layer 2, base should be
           globally shared
         </p>
-        <ScopeProvider atoms={[baseAtom2]}>
+        <ScopeProvider atoms={[baseAtom2]} name="layer2">
           <Counter counterClass="layer2" />
         </ScopeProvider>
       </ScopeProvider>

--- a/tests/ScopeProvider/07_writable.test.tsx
+++ b/tests/ScopeProvider/07_writable.test.tsx
@@ -3,7 +3,7 @@ import type { PrimitiveAtom, WritableAtom } from 'jotai'
 import { atom, useAtom } from 'jotai'
 import { describe, expect, test } from 'vitest'
 import { ScopeProvider } from '../../src'
-import { scope } from '../../src/ScopeProvider/scope'
+import { createScope } from '../../src/ScopeProvider/scope'
 import { AnyAtom } from '../../src/types'
 import { clickButton, createDebugStore, getTextContents } from '../utils'
 
@@ -177,12 +177,7 @@ describe('scope chains', () => {
   c.debugLabel = 'c'
   function createScopes(atoms: AnyAtom[] = []) {
     const s0 = createDebugStore()
-    const s1 = scope({
-      atomSet: new Set(atoms),
-      atomFamilySet: undefined,
-      parentStore: s0,
-      name: 'S1',
-    })
+    const s1 = createScope({ atoms, parentStore: s0, name: 'S1' })
     return { s0, s1 }
   }
   test('S1[a]: a1, b0(,a1), c0(,b0(,a1))', () => {

--- a/tests/ScopeProvider/07_writable.test.tsx
+++ b/tests/ScopeProvider/07_writable.test.tsx
@@ -3,7 +3,7 @@ import type { PrimitiveAtom, WritableAtom } from 'jotai'
 import { atom, useAtom } from 'jotai'
 import { describe, expect, test } from 'vitest'
 import { ScopeProvider } from '../../src'
-import { createScope } from '../../src/ScopeProvider/scope'
+import { scope } from '../../src/ScopeProvider/scope'
 import { AnyAtom } from '../../src/types'
 import { clickButton, createDebugStore, getTextContents } from '../utils'
 
@@ -177,7 +177,7 @@ describe('scope chains', () => {
   c.debugLabel = 'c'
   function createScopes(atoms: AnyAtom[] = []) {
     const s0 = createDebugStore()
-    const s1 = createScope({
+    const s1 = scope({
       atomSet: new Set(atoms),
       atomFamilySet: undefined,
       parentStore: s0,

--- a/tests/effect.test.tsx
+++ b/tests/effect.test.tsx
@@ -1,8 +1,9 @@
 import { render } from '@testing-library/react'
 import { Provider, atom, useAtomValue } from 'jotai'
 import { atomEffect } from 'jotai-effect'
-import { describe, expect, test } from 'vitest'
 import { ScopeProvider } from 'jotai-scope'
+// eslint-disable-next-line import/order
+import { describe, expect, test } from 'vitest'
 import { createDebugStore } from './utils'
 
 describe('atomEffect', () => {

--- a/tests/effect.test.tsx
+++ b/tests/effect.test.tsx
@@ -1,33 +1,32 @@
-// import { render } from '@testing-library/react'
-// import { Provider, atom, useAtomValue } from 'jotai'
-// import { atomEffect } from 'jotai-effect'
-import { describe, /*  expect, */ test } from 'vitest'
-// import { ScopeProvider } from 'jotai-scope'
-// import { createDebugStore } from './utils'
+import { render } from '@testing-library/react'
+import { Provider, atom, useAtomValue } from 'jotai'
+import { atomEffect } from 'jotai-effect'
+import { describe, expect, test } from 'vitest'
+import { ScopeProvider } from 'jotai-scope'
+import { createDebugStore } from './utils'
 
-describe.skip('atomEffect', () => {
+describe('atomEffect', () => {
   test('should work with atomEffect', () => {
-    // // const effect = vi.fn()
-    // const a = atom(0)
-    // a.debugLabel = 'atomA'
-    // const e = atomEffect((_get, set) => {
-    //   set(a, (v) => v + 1)
-    // })
-    // e.debugLabel = 'effect'
-    // const s0 = createDebugStore('s0')
-    // function Component() {
-    //   useAtomValue(e)
-    //   const v = useAtomValue(a)
-    //   return <div className="value">{v}</div>
-    // }
-    // const { container } = render(
-    //   <Provider store={s0}>
-    //     <ScopeProvider atoms={[a]} name="S1">
-    //       <Component />
-    //     </ScopeProvider>
-    //   </Provider>
-    // )
-    // expect(container.querySelector('.value')!.textContent).toBe('1')
-    // expect(s0.get(a)).toBe(0)
+    const a = atom(0)
+    a.debugLabel = 'atomA'
+    const e = atomEffect((_get, set) => {
+      set(a, (v) => v + 1)
+    })
+    e.debugLabel = 'effect'
+    const s0 = createDebugStore('s0')
+    function Component() {
+      useAtomValue(e)
+      const v = useAtomValue(a)
+      return <div className="value">{v}</div>
+    }
+    const { container } = render(
+      <Provider store={s0}>
+        <ScopeProvider atoms={[a]} name="S1">
+          <Component />
+        </ScopeProvider>
+      </Provider>
+    )
+    expect(container.querySelector('.value')!.textContent).toBe('1')
+    expect(s0.get(a)).toBe(0)
   })
 })

--- a/tests/issues.test.ts
+++ b/tests/issues.test.ts
@@ -1,6 +1,6 @@
 import { atom } from 'jotai'
 import { describe, expect, it, vi } from 'vitest'
-import { createScope } from '../src/ScopeProvider/scope'
+import { scope } from '../src/ScopeProvider/scope'
 import { createDebugStore } from './utils'
 
 describe('open issues', () => {
@@ -22,7 +22,7 @@ describe('open issues', () => {
       console.log('S0: atomA changed')
     })
 
-    const s1 = createScope({
+    const s1 = scope({
       atomSet: new Set([a]),
       atomFamilySet: new Set(),
       parentStore: s0,
@@ -57,7 +57,7 @@ describe('open issues', () => {
         console.log('S1', s0.get(a))
       })
 
-      const s1 = createScope({
+      const s1 = scope({
         atomSet: new Set([a]),
         atomFamilySet: new Set(),
         parentStore: s0,

--- a/tests/issues.test.ts
+++ b/tests/issues.test.ts
@@ -1,6 +1,6 @@
 import { atom } from 'jotai'
 import { describe, expect, it, vi } from 'vitest'
-import { scope } from '../src/ScopeProvider/scope'
+import { createScope } from '../src/ScopeProvider/scope'
 import { createDebugStore } from './utils'
 
 describe('open issues', () => {
@@ -22,9 +22,8 @@ describe('open issues', () => {
       console.log('S0: atomA changed')
     })
 
-    const s1 = scope({
-      atomSet: new Set([a]),
-      atomFamilySet: new Set(),
+    const s1 = createScope({
+      atoms: [a],
       parentStore: s0,
       name: 's1',
     })
@@ -57,9 +56,8 @@ describe('open issues', () => {
         console.log('S1', s0.get(a))
       })
 
-      const s1 = scope({
-        atomSet: new Set([a]),
-        atomFamilySet: new Set(),
+      const s1 = createScope({
+        atoms: [a],
         parentStore: s0,
         name: 's1',
       })


### PR DESCRIPTION
## Background
Prior to jotai@2.14.0 we had two sets of Building Blocks, (1) internal, (2) external. The internal building blocks are passed to buildStore to build the scoped store. The external building blocks are the property value under the BUILDING_BLOCKS symbol on the scopedStore. We mutated this array to replace these building blocks with shimmed versions. The shim just calls `getAtom(atom): scopedAtom` to convert an atom arg to a scoped atom arg. This is required for jotai-effect to work properly inside a scope.

Now with jotai@2.14.0, we can no longer mutate the array since it is marked runtime immutable with Object.freeze. Also, even if we could, it is now the same building blocks as internal. There is only one set of building blocks with jotai@2.14.0.

## This change
We add the shim to our internal building blocks by taking advantage of the new building block prop 25 introduced in jotai@2.15.0.
